### PR TITLE
simplify the code by making member fields public

### DIFF
--- a/include/modb/Plane.h
+++ b/include/modb/Plane.h
@@ -13,11 +13,13 @@ namespace modb {
         Point mbrLocation;
         float mbrWidth;
 
-        Plane() = default;
+        Plane();
 
-        Plane(Plane& other) = default;
+        Plane(Plane& other);
 
-        ~Plane() = default;
+        Plane(Plane&& other);
+
+        Plane(std::string oid, Point baseLocation, Point mbrLocation, float mbrWidth);
 
         template <class Archive>
         inline void serialize(Archive& ar, unsigned int) {

--- a/include/modb/Point.h
+++ b/include/modb/Point.h
@@ -7,11 +7,13 @@ namespace modb {
         float longitude;
         float latitude;
 
-        Point() = default;
+        Point();
 
-        Point(Point& other) = default;
+        Point(Point& other);
 
-        ~Point() = default;
+        Point(Point&& other);
+
+        Point(float longitude, float latitude);
 
         template <class Archive>
         inline void serialize(Archive& ar, unsigned int) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,4 +38,6 @@ add_executable(${TARGET_NAME})
 
 target_sources(${TARGET_NAME} 
     PRIVATE main.cpp
+    PRIVATE Plane.cpp
+    PRIVATE Point.cpp
 )

--- a/src/Plane.cpp
+++ b/src/Plane.cpp
@@ -1,0 +1,29 @@
+#include <modb/Plane.h>
+
+#include <utility>
+
+namespace modb {
+    Plane::Plane():
+        oid{},
+        baseLocation{},
+        mbrLocation{},
+        mbrWidth{} {}
+
+    Plane::Plane(Plane& other):
+        oid{ other.oid },
+        baseLocation{ other.baseLocation },
+        mbrLocation{ other.mbrLocation },
+        mbrWidth{ other.mbrWidth } {}
+
+    Plane::Plane(Plane&& other):
+        oid{ std::move(other.oid) },
+        baseLocation{ std::move(other.baseLocation) },
+        mbrLocation{ std::move(other.mbrLocation) },
+        mbrWidth{ std::exchange(other.mbrWidth, 0) } {}
+
+    Plane::Plane(std::string oid, Point baseLocation, Point mbrLocation, float mbrWidth):
+        oid{ oid },
+        baseLocation{ baseLocation },
+        mbrLocation{ mbrLocation },
+        mbrWidth{ mbrWidth } {}
+}

--- a/src/Point.cpp
+++ b/src/Point.cpp
@@ -1,0 +1,21 @@
+#include <modb/Point.h>
+
+#include <utility>
+
+namespace modb {
+    Point::Point():
+        longitude{},
+        latitude{} {}
+
+    Point::Point(Point& other):
+        longitude{ other.longitude },
+        latitude{ other.latitude } {}
+
+    Point::Point(Point&& other):
+        longitude{ std::exchange(other.longitude, 0) },
+        latitude{ std::exchange(other.latitude, 0) } {}
+
+    Point::Point(float longitude, float latitude):
+        longitude{ longitude },
+        latitude{ latitude } {}
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,7 @@ int exampleLoad() {
         planeDB.set_error_stream(&std::cerr);
         planeDB.open(NULL, dbFileName.c_str(), NULL, DB_BTREE, DB_CREATE, 0);
 
-        const modb::Plane plane{ "a3a5d9", { 1.2, 1.3 }, { 2.2, 1.2 }, 1.1 };
+        const modb::Plane plane{ "a3a5d9", { 12.2354, 17.3522 }, { 65.4543, 95.1235 }, 36.9276 };
 
         std::ostringstream outputStream{};
         boost::archive::binary_oarchive outputArchive(outputStream);
@@ -53,10 +53,12 @@ int exampleLoad() {
         std::istringstream inputStream{inputBuffer};
         boost::archive::binary_iarchive inputArchive{inputStream};
 
-        modb::Plane readRecord;
-        inputArchive >> readRecord;
+        modb::Plane tmpPlane;
+        inputArchive >> tmpPlane;
 
-        std::cout << "key is " << readRecord.oid << std::endl;
+        const modb::Plane retPLane{std::move(tmpPlane)};
+
+        std::cout << "key is " << retPLane.oid << std::endl;
     }
     catch (DbException& e)
     {


### PR DESCRIPTION
Turned member variables for Plane to public in order to simplify the code.

Wrote constructor definitions for Plane and Point classes.